### PR TITLE
Fix unit tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libopencm3"]
 	path = libopencm3
-	url = git@github.com:libopencm3/libopencm3.git
+	url = https://github.com/libopencm3/libopencm3.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,55 @@
+language: cpp
+compiler:
+    - gcc
+    - clang
+
+before_install:
+
+      # Install cpputest
+    - pushd ..
+    - wget "https://github.com/cpputest/cpputest.github.io/blob/master/releases/cpputest-3.6.tar.gz?raw=true" -O cpputest.tar.gz
+    - tar -xzf cpputest.tar.gz 
+    - cd cpputest-3.6/
+    - ./configure
+    - make
+    - sudo make install
+    - popd
+
+    # Install packager.py
+    - sudo pip install pyaml jinja2
+    - git clone https://github.com/cvra/packager ../packager
+
+    # Install test environment for the client
+    - sudo apt-get install python-virtualenv python3
+    - python3 --version
+
+before_script:    
+    # Create client test environment
+    - virtualenv --python=python3 venv
+    - source venv/bin/activate
+    - python --version
+    - pip install -r client/requirements.txt
+    - pip install mock # python 3.2 doesn't have unittest.mock
+    - deactivate
+
+    # Prepare bootloader build
+    - ../packager/packager.py
+    - mkdir build/
+    - pushd build/
+    - cmake ..
+    - popd
+
+script: 
+    # Booloader tests
+    - pushd build/
+    - make
+    - ./tests
+    - popd
+
+    # Client tests
+    - source venv/bin/activate
+    - pushd client/
+    - python -m unittest2
+    - deactivate
+    - popd
+

--- a/boot_arg.h
+++ b/boot_arg.h
@@ -1,6 +1,10 @@
 #ifndef BOOT_ARG_H
 #define BOOT_ARG_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 
 #define BOOT_ARG_START_BOOTLOADER               0x00
@@ -9,5 +13,9 @@
 #define BOOT_ARG_START_ST_BOOTLOADER            0x03
 
 void reboot(uint8_t arg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // BOOT_ARG_H

--- a/config.c
+++ b/config.c
@@ -31,7 +31,7 @@ void config_write(void *buffer, bootloader_config_t *config, size_t buffer_size)
     serializer_init(&serializer, block_payload_get(buffer), buffer_size - 4);
     serializer_cmp_ctx_factory(&context, &serializer);
 
-    cmp_write_map(&context, 4);
+    cmp_write_map(&context, 6);
 
     cmp_write_str(&context, "ID", 2);
     cmp_write_u8(&context, config->ID);

--- a/memory.h
+++ b/memory.h
@@ -1,0 +1,22 @@
+#ifndef MEMORY_H
+#define MEMORY_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <stddef.h>
+
+extern const size_t page_size;
+extern uint8_t page_buffer[];
+
+void *memory_get_app_addr(void);
+void *memory_get_config1_addr(void);
+void *memory_get_config2_addr(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MEMORY_H */

--- a/package.yml
+++ b/package.yml
@@ -13,6 +13,7 @@ tests:
     - tests/config_commands_tests.cpp
     - tests/datagrams_command_tests.cpp
     - tests/integration_tests.cpp
+    - tests/mocks/memory_mock.c
 
 source:
     - can_datagram.c

--- a/package.yml
+++ b/package.yml
@@ -5,13 +5,12 @@ depends:
 
 tests:
     - tests/can_datagram_tests.cpp
-    - tests/datagrams_command_tests.cpp
     - tests/mocks/flash_writer_mock.cpp
     - tests/mocks/can_interface_mock.cpp
+    - tests/mocks/boot_arg.cpp
     - tests/config_tests.cpp
     - tests/flash_command_tests.cpp
     - tests/config_commands_tests.cpp
-    - tests/integration_tests.cpp
 
 source:
     - can_datagram.c

--- a/package.yml
+++ b/package.yml
@@ -12,6 +12,7 @@ tests:
     - tests/flash_command_tests.cpp
     - tests/config_commands_tests.cpp
     - tests/datagrams_command_tests.cpp
+    - tests/integration_tests.cpp
 
 source:
     - can_datagram.c

--- a/package.yml
+++ b/package.yml
@@ -11,6 +11,7 @@ tests:
     - tests/config_tests.cpp
     - tests/flash_command_tests.cpp
     - tests/config_commands_tests.cpp
+    - tests/datagrams_command_tests.cpp
 
 source:
     - can_datagram.c

--- a/tests/config_tests.cpp
+++ b/tests/config_tests.cpp
@@ -84,7 +84,7 @@ TEST_GROUP(ConfigSerializationTest)
 
     void config_read_and_write()
     {
-        config_write(config_buffer, config, sizeof config_buffer);
+        config_write(config_buffer, &config, sizeof config_buffer);
         result = config_read(config_buffer, sizeof config_buffer);
     }
 };
@@ -123,4 +123,22 @@ TEST(ConfigSerializationTest, CanSerializeApplicationCRC)
     config_read_and_write();
 
     CHECK_EQUAL(0xdeadbeef, result.application_crc);
+}
+
+TEST(ConfigSerializationTest, CanSerializeApplicationSize)
+{
+    config.application_size = 42;
+
+    config_read_and_write();
+
+    CHECK_EQUAL(42, result.application_size);
+}
+
+TEST(ConfigSerializationTest, CanSerializeUpdateCount)
+{
+    config.update_count = 23;
+
+    config_read_and_write();
+
+    CHECK_EQUAL(23, result.update_count);
 }

--- a/tests/datagrams_command_tests.cpp
+++ b/tests/datagrams_command_tests.cpp
@@ -33,9 +33,9 @@ TEST_GROUP(ProtocolCommandTestGroup)
 
 TEST(ProtocolCommandTestGroup, CommandIsCalled)
 {
-    command_t commands[] = {
-        {.index = 0x00, .callback = mock_command},
-    };
+    command_t commands[1];
+    commands[0].index = 0x00;
+    commands[0].callback = mock_command;
 
     cmp_write_uint(&command_builder, 0x0);
 
@@ -48,10 +48,11 @@ TEST(ProtocolCommandTestGroup, CommandIsCalled)
 
 TEST(ProtocolCommandTestGroup, CorrectCommandIsCalled)
 {
-    command_t commands[] = {
-        {.index = 0x00, .callback = NULL},
-        {.index = 0x02, .callback = mock_command},
-    };
+    command_t commands[2];
+    commands[0].index = 0x00;
+    commands[0].callback = NULL;
+    commands[1].index = 0x02;
+    commands[1].callback = mock_command;
 
     // Write command index
     cmp_write_uint(&command_builder, 0x2);
@@ -70,9 +71,9 @@ void argc_log_command(int argc, cmp_ctx_t *dummy, cmp_ctx_t *out, bootloader_con
 
 TEST(ProtocolCommandTestGroup, CorrectArgcIsSent)
 {
-    command_t commands[] = {
-        {.index = 0x02, .callback = argc_log_command},
-    };
+    command_t commands[1];
+    commands[0].index = 0x02;
+    commands[0].callback = argc_log_command;
 
     // Write command index
     cmp_write_uint(&command_builder, 0x2);
@@ -100,9 +101,9 @@ void args_log_command(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloader_conf
 
 TEST(ProtocolCommandTestGroup, CanReadArgs)
 {
-    command_t commands[] = {
-        {.index = 0x02, .callback = args_log_command},
-    };
+    command_t commands[1];
+    commands[0].index = 0x02;
+    commands[0].callback = args_log_command;
 
     // Command index
     cmp_write_uint(&command_builder, 0x2);
@@ -130,9 +131,10 @@ void dummy_command(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloader_config_
 TEST(ProtocolCommandTestGroup, ExecuteReturnsZeroWhenValidCommand)
 {
     int result;
-    command_t commands[] = {
-        {.index = 0x00, .callback = dummy_command},
-    };
+
+    command_t commands[1];
+    commands[0].index = 0x00;
+    commands[0].callback = dummy_command;
 
     // Command index
     cmp_write_uint(&command_builder, 0x0);
@@ -147,9 +149,9 @@ TEST(ProtocolCommandTestGroup, ExecuteReturnsZeroWhenValidCommand)
 TEST(ProtocolCommandTestGroup, ExecuteInvalidCommand)
 {
     int result;
-    command_t commands[] = {
-        {.index = 0x00, .callback = dummy_command},
-    };
+    command_t commands[1];
+    commands[0].index = 0x00;
+    commands[0].callback = dummy_command;
 
     // Invalid command index, here a float
     cmp_write_float(&command_builder, 3.14);
@@ -164,9 +166,9 @@ TEST(ProtocolCommandTestGroup, ExecuteInvalidCommand)
 TEST(ProtocolCommandTestGroup, ExecuteWithoutArgumentsMeansArgcZero)
 {
     int result;
-    command_t commands[] = {
-        {.index = 0x01, .callback = argc_log_command},
-    };
+    command_t commands[1];
+    commands[0].index = 0x01;
+    commands[0].callback = argc_log_command;
 
     cmp_write_uint(&command_builder, 1);
 
@@ -182,9 +184,10 @@ TEST(ProtocolCommandTestGroup, ExecuteWithoutArgumentsMeansArgcZero)
 TEST(ProtocolCommandTestGroup, CallingNonExistingFunctionReturnsCorrectErrorCode)
 {
     int result;
-    command_t commands[] = {
-        {.index = 0x00, .callback = argc_log_command},
-    };
+
+    command_t commands[1];
+    commands[0].index = 0x00;
+    commands[0].callback = argc_log_command;
 
     // Non existing command
     cmp_write_uint(&command_builder, 1);
@@ -227,9 +230,9 @@ void output_mock_command(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloader_c
 TEST(ProtocolOutputCommand, CanPassOutputBuffer)
 {
     int result;
-    command_t commands[] = {
-        {.index = 0x01, .callback = output_mock_command},
-    };
+    command_t commands[1];
+    commands[0].index = 0x01;
+    commands[0].callback = output_mock_command;
 
     cmp_write_uint(&command_builder, 1);
 
@@ -242,10 +245,9 @@ TEST(ProtocolOutputCommand, CanPassOutputBuffer)
 TEST(ProtocolOutputCommand, BytesCountIsReturned)
 {
     int result;
-
-    command_t commands[] = {
-        {.index = 0x01, .callback = output_mock_command},
-    };
+    command_t commands[1];
+    commands[0].index = 0x01;
+    commands[0].callback = output_mock_command;
 
     cmp_write_uint(&command_builder, 1);
 

--- a/tests/datagrams_command_tests.cpp
+++ b/tests/datagrams_command_tests.cpp
@@ -41,7 +41,7 @@ TEST(ProtocolCommandTestGroup, CommandIsCalled)
 
     mock().expectOneCall("command");
 
-    protocol_execute_command(command_data, commands, LEN(commands), NULL, NULL);
+    protocol_execute_command(command_data, sizeof command_data, commands, LEN(commands), NULL, 0, NULL);
 
     mock().checkExpectations();
 }
@@ -58,7 +58,7 @@ TEST(ProtocolCommandTestGroup, CorrectCommandIsCalled)
 
     mock().expectOneCall("command");
 
-    protocol_execute_command(command_data, commands, LEN(commands), NULL, NULL);
+    protocol_execute_command(command_data, sizeof command_data, commands, LEN(commands), NULL, 0, NULL);
 
     mock().checkExpectations();
 }
@@ -82,7 +82,7 @@ TEST(ProtocolCommandTestGroup, CorrectArgcIsSent)
 
     mock().expectOneCall("command").withIntParameter("argc", 42);
 
-    protocol_execute_command(command_data, commands, LEN(commands), NULL, NULL);
+    protocol_execute_command(command_data, sizeof command_data, commands, LEN(commands), NULL, 0, NULL);
 
     mock().checkExpectations();
 }
@@ -118,7 +118,7 @@ TEST(ProtocolCommandTestGroup, CanReadArgs)
           .withIntParameter("a", 42)
           .withIntParameter("b", 43);
 
-    protocol_execute_command(command_data, commands, LEN(commands), NULL, NULL);
+    protocol_execute_command(command_data, sizeof command_data, commands, LEN(commands), NULL, 0, NULL);
 
     mock().checkExpectations();
 }
@@ -140,7 +140,7 @@ TEST(ProtocolCommandTestGroup, ExecuteReturnsZeroWhenValidCommand)
     // Argument array length
     cmp_write_array(&command_builder, 0);
 
-    result = protocol_execute_command(command_data, commands, LEN(commands), NULL, NULL);
+    result = protocol_execute_command(command_data, sizeof command_data, commands, LEN(commands), NULL, 0, NULL);
     CHECK_EQUAL(0, result);
 }
 
@@ -157,7 +157,7 @@ TEST(ProtocolCommandTestGroup, ExecuteInvalidCommand)
     // Argument array length
     cmp_write_array(&command_builder, 0);
 
-    result = protocol_execute_command(command_data, commands, LEN(commands), NULL, NULL);
+    result = protocol_execute_command(command_data, sizeof command_data, commands, LEN(commands), NULL, 0, NULL);
     CHECK_EQUAL(-ERR_INVALID_COMMAND, result);
 }
 
@@ -172,7 +172,7 @@ TEST(ProtocolCommandTestGroup, ExecuteWithoutArgumentsMeansArgcZero)
 
     mock().expectOneCall("command").withIntParameter("argc", 0);
 
-    result = protocol_execute_command(command_data, commands, LEN(commands), NULL, NULL);
+    result = protocol_execute_command(command_data, sizeof command_data, commands, LEN(commands), NULL, 0, NULL);
 
     CHECK_EQUAL(0, result);
 
@@ -189,7 +189,7 @@ TEST(ProtocolCommandTestGroup, CallingNonExistingFunctionReturnsCorrectErrorCode
     // Non existing command
     cmp_write_uint(&command_builder, 1);
 
-    result = protocol_execute_command(command_data, commands, LEN(commands), NULL, NULL);
+    result = protocol_execute_command(command_data, sizeof command_data, commands, LEN(commands), NULL, 0, NULL);
 
     CHECK_EQUAL(-ERR_COMMAND_NOT_FOUND, result);
 }
@@ -233,7 +233,7 @@ TEST(ProtocolOutputCommand, CanPassOutputBuffer)
 
     cmp_write_uint(&command_builder, 1);
 
-    protocol_execute_command(command_data, commands, LEN(commands), output_data, NULL);
+    protocol_execute_command(command_data, sizeof command_data, commands, LEN(commands), output_data, sizeof output_data, NULL);
 
     BYTES_EQUAL(0xa5, output_data[0]); // string of length 5
     STRCMP_EQUAL("Hello", &output_data[1]);
@@ -249,7 +249,7 @@ TEST(ProtocolOutputCommand, BytesCountIsReturned)
 
     cmp_write_uint(&command_builder, 1);
 
-    result = protocol_execute_command(command_data, commands, LEN(commands), output_data, NULL);
+    result = protocol_execute_command(command_data, sizeof command_data, commands, LEN(commands), output_data, sizeof output_data, NULL);
 
     CHECK_EQUAL(6, result);
 }

--- a/tests/integration_tests.cpp
+++ b/tests/integration_tests.cpp
@@ -23,7 +23,7 @@ void read_eval(can_datagram_t *input, can_datagram_t *output, bootloader_config_
     if (can_datagram_is_valid(input)) {
         for (i = 0; i < input->destination_nodes_len; ++i) {
             if (input->destination_nodes[i] == config->ID){
-                len = protocol_execute_command((char *)input->data, commands, command_len, (char *)output->data, config);
+                len = protocol_execute_command((char *)input->data, input->data_len, commands, command_len, (char *)output->data, output->data_len, config);
 
                 /* Checks if there was any error. */
                 if (len < 0) {
@@ -56,11 +56,11 @@ TEST_GROUP(IntegrationTesting)
     void setup(void)
     {
         can_datagram_init(&input_datagram);
-        can_datagram_set_adress_buffer(&input_datagram, input_datagram_destinations);
+        can_datagram_set_address_buffer(&input_datagram, input_datagram_destinations);
         can_datagram_set_data_buffer(&input_datagram, input_datagram_data, sizeof input_datagram_data);
 
         can_datagram_init(&output_datagram);
-        can_datagram_set_adress_buffer(&output_datagram, output_datagram_destinations);
+        can_datagram_set_address_buffer(&output_datagram, output_datagram_destinations);
         can_datagram_set_data_buffer(&output_datagram, output_datagram_data, sizeof output_datagram_data);
 
         // Loads default config for testing

--- a/tests/mocks/boot_arg.cpp
+++ b/tests/mocks/boot_arg.cpp
@@ -1,0 +1,11 @@
+#include "CppUTest/TestHarness.h"
+#include "CppUTestExt/MockSupport.h"
+
+extern "C" {
+#include "../../boot_arg.h"
+}
+
+void reboot(uint8_t arg)
+{
+    mock().actualCall("reboot").withIntParameter("arg", arg);
+}

--- a/tests/mocks/flash_writer_mock.cpp
+++ b/tests/mocks/flash_writer_mock.cpp
@@ -71,9 +71,9 @@ TEST(FlashWriterMockTestGroup, CanWritePage)
 
     mock("flash").expectOneCall("page_write")
                  .withPointerParameter("page_adress", buf)
-                 .withIntParameter("size", 5);
+                 .withIntParameter("size", strlen(data) + 1);
 
-    flash_writer_page_write(buf, data, 5);
+    flash_writer_page_write(buf, data, strlen(data) + 1);
 
     STRCMP_EQUAL(data, buf);
 }

--- a/tests/mocks/flash_writer_mock.cpp
+++ b/tests/mocks/flash_writer_mock.cpp
@@ -3,6 +3,10 @@
 #include "CppUTest/TestHarness.h"
 #include "CppUTestExt/MockSupport.h"
 
+// This symbol is supposed to be provided by the linker
+extern "C" {
+int app_start;
+}
 
 void flash_writer_unlock(void)
 {

--- a/tests/mocks/memory_mock.c
+++ b/tests/mocks/memory_mock.c
@@ -1,0 +1,24 @@
+#include "memory_mock.h"
+
+uint8_t config1[64];
+uint8_t config2[64];
+uint8_t page_buffer[64];
+const size_t page_size = sizeof(page_buffer);
+
+int app;
+
+void *memory_get_app_addr(void)
+{
+    return &app;
+}
+
+void *memory_get_config1_addr(void)
+{
+    return &config1[0];
+}
+
+void *memory_get_config2_addr(void)
+{
+    return &config2[0];
+}
+

--- a/tests/mocks/memory_mock.h
+++ b/tests/mocks/memory_mock.h
@@ -1,0 +1,20 @@
+#ifndef MEMORY_MOCK_H
+#define MEMORY_MOCK_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "../../memory.h"
+
+extern uint8_t config1[64];
+extern uint8_t config2[64];
+extern uint8_t page_buffer[64];
+
+extern int app;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MEMORY_MOCK_H */


### PR DESCRIPTION
This patchset fixes the unit test build and also adds a few tests for the jump command.

I think we should really try to keep those tests working, because having a reliable build on Linux will allow us to use advanced quality tools such as static analyzers, etc. I can play QA guy and add those tests after each pull request, but it would be easier for everyone if those who write the code also write the tests during development.
