### PR TITLE
Correct CAN ID format (fix #25)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,9 +21,9 @@ There is one bit to indicate if this message is the first of a datagram (1) or i
 
 The format of the CAN message ID is :
 
-* 7 bits for the source ID
-* 1 bit for start of datagram bit
-* 3 reserved bits
+* bits 10..8: 3 reserved bits, set to zero for bootloader frames
+* bit 7: 1 bit for start of datagram bit (1 if first frame in datagram, 0 otherwise)
+* bits 6..0: bits for the source ID
 
 ## CAN Datagram format
 The CAN datagram layer has the following resposibilities :

--- a/can_datagram.c
+++ b/can_datagram.c
@@ -3,6 +3,8 @@
 #include "can_datagram.h"
 #include <crc/crc32.h>
 
+#define ID_START_MASK (1 << 7)
+
 enum {
     STATE_PROTOCOL_VERSION,
     STATE_CRC,
@@ -192,4 +194,9 @@ uint32_t can_datagram_compute_crc(can_datagram_t *dt)
     crc = crc32(crc, tmp, 4);
     crc = crc32(crc, &dt->data[0], dt->data_len);
     return crc;
+}
+
+bool can_datagram_id_start_is_set(unsigned int id)
+{
+    return id & ID_START_MASK;
 }

--- a/can_datagram.h
+++ b/can_datagram.h
@@ -64,6 +64,9 @@ int can_datagram_output_bytes(can_datagram_t *dt, char *buffer, size_t buffer_le
 /** Computes the CRC32 of the datagram. */
 uint32_t can_datagram_compute_crc(can_datagram_t *dt);
 
+/** Returns true if the ID has the start of datagram field set. */
+bool can_datagram_id_start_is_set(unsigned int id);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/can_datagram_tests.cpp
+++ b/tests/can_datagram_tests.cpp
@@ -472,3 +472,15 @@ TEST(CANDatagramOutputTestGroup, IfWeStopEarlierBytesWrittenIsReturned)
 
     CHECK_EQUAL(3, ret);
 }
+
+TEST_GROUP(CANIDTestGroup)
+{
+};
+
+TEST(CANIDTestGroup, CanFindIfStartOfDatagram)
+{
+    int source_id = 0x2;
+    int start_bit = (1 << 7);
+    CHECK_FALSE(can_datagram_id_start_is_set(source_id));
+    CHECK_TRUE(can_datagram_id_start_is_set(source_id | start_bit));
+}


### PR DESCRIPTION
This fix issue #25. I think there wasn't a need for code change, but the documentation was not really clear about bit ordering. Hopefully it is fixed now, let me know if this is not the case.

I also added a function to check if it is the start of a datagram, since I feel it is cleaner to do it here, rather than in user code.
