### PR TITLE
Separate flash write and page erase commands

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -80,11 +80,12 @@ They should simply send the MessagePack encoded response on the bus.
 
 1. Jump to application (0x01). No parameters. Simply starts the application code.
 2. CRC flash region (0x02). 2 parameters : start adress and length of the region we want to check. Returns the CRC32 of this region.
-3. Write flash (0x03). Parameters : Start adress, device class (string) and sequence of bytes to write. Returns nothing.
-4. Read flash (0x04). Parameters : Start adress and length. Returns sequence of read bytes
-5. Check write status (0x05). Parameters: None. Returns: True if a write is currently in progress, False otherwise.
-6. Update config (0x06). The only parameters is a MessagePack map containing the configuration values to update. If a config value is not in its parameters, it will not be changed.
-7. Save config to flash.
+3. Erase flash page (0x03). Parameters : Page address, device class (string). Returns nothing.
+4. Write flash (0x04). Parameters : Start adress, device class (string) and sequence of bytes to write. Returns nothing.
+5. Read flash (0x05). Parameters : Start adress and length. Returns sequence of read bytes
+6. Check write status (0x06). Parameters: None. Returns: True if a write is currently in progress, False otherwise.
+7. Update config (0x07). The only parameters is a MessagePack map containing the configuration values to update. If a config value is not in its parameters, it will not be changed.
+8. Save config to flash.
 
 *Note:* Adresses (pointers) in the arguments are represented as 64 bits integers.
 64 bits was chosen to allow tests to run on 64 bits platforms too.

--- a/command.c
+++ b/command.c
@@ -7,6 +7,34 @@
 #include "command.h"
 #include "memory.h"
 
+void command_erase_flash_page(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloader_config_t *config)
+{
+    void *address;
+    uint64_t tmp;
+    char device_class[64];
+
+    cmp_read_uinteger(args, &tmp);
+    address = (void *)tmp;
+
+    // refuse to overwrite bootloader or config pages
+    if (address < memory_get_app_addr()) {
+        return;
+    }
+
+    uint32_t size = 64;
+    cmp_read_str(args, device_class, &size);
+
+    if (strcmp(device_class, config->device_class) != 0) {
+        return;
+    }
+
+    flash_writer_unlock();
+
+    flash_writer_page_erase(address);
+
+    flash_writer_lock();
+}
+
 void command_write_flash(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloader_config_t *config)
 {
     void *address;

--- a/command.c
+++ b/command.c
@@ -67,8 +67,6 @@ void command_write_flash(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloader_c
 
     flash_writer_unlock();
 
-    flash_writer_page_erase(address);
-
     flash_writer_page_write(address, src, size);
 
     flash_writer_lock();

--- a/command.h
+++ b/command.h
@@ -43,6 +43,12 @@ typedef struct {
  */
 int protocol_execute_command(char *data, size_t data_len, command_t *commands, int command_len, char *out_buf, size_t out_len, bootloader_config_t *config);
 
+/** Command used to erase a flash page.
+ *
+ * @note Should not be called directly but be a part of the commands given to protocol_execute_command.
+ */
+void command_erase_flash_page(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloader_config_t *config);
+
 /** Command used to write to a flash page.
  *
  * @note Should not be called directly but be a part of the commands given to protocol_execute_command.

--- a/tests/flash_command_tests.cpp
+++ b/tests/flash_command_tests.cpp
@@ -86,6 +86,46 @@ TEST(FlashCommandTestGroup, CheckThatDeviceClassIsRespected)
     mock().checkExpectations();
 }
 
+TEST(FlashCommandTestGroup, CanErasePage)
+{
+    int page;
+
+    // Writes the adress of the page
+    cmp_write_u64(&command_builder, (size_t)&page);
+
+    // Writes the correct device class
+    cmp_write_str(&command_builder, config.device_class, strlen(config.device_class));
+
+    mock("flash").expectOneCall("unlock");
+    mock("flash").expectOneCall("lock");
+
+    mock("flash").expectOneCall("page_erase").withPointerParameter("adress", &page);
+
+    command_erase_flash_page(1, &command_builder, NULL, &config);
+
+    mock().checkExpectations();
+}
+
+TEST(FlashCommandTestGroup, DeviceClassIsRespectedForErasePage)
+{
+    // Writes the adress of the page
+    cmp_write_u64(&command_builder, (size_t)&page);
+
+    // Writes the correct device class
+    cmp_write_str(&command_builder, "fail", 4);
+
+    command_erase_flash_page(1, &command_builder, NULL, &config);
+
+    mock().checkExpectations();
+}
+
+TEST(FlashCommandTestGroup, CheckIllFormatedArgumentsForErasePage)
+{
+    command_erase_flash_page(1, &command_builder, NULL, &config);
+
+    mock().checkExpectations();
+}
+
 TEST_GROUP(JumpToApplicationCodetestGroup)
 {
     bootloader_config_t config;

--- a/tests/flash_command_tests.cpp
+++ b/tests/flash_command_tests.cpp
@@ -48,7 +48,6 @@ TEST(FlashCommandTestGroup, CanFlashSinglePage)
 
     mock("flash").expectOneCall("unlock");
     mock("flash").expectOneCall("lock");
-    mock("flash").expectOneCall("page_erase").withPointerParameter("adress", page);
 
     mock("flash").expectOneCall("page_write")
                  .withPointerParameter("page_adress", page)


### PR DESCRIPTION
This separates the flash page erase from the flash write to allow multiple page writes to the same flash page.
Addresses issue #37.
