### PR TITLE
TCP/IP  bridge support in flasher

### DIFF
--- a/client/bootloader_flash.py
+++ b/client/bootloader_flash.py
@@ -156,6 +156,14 @@ def verification_failed(failed_nodes):
     print(error_msg)
     exit(1)
 
+def open_connection(args):
+    """
+    Open a connection based on commandline arguments.
+
+    Returns a file like object which will be the connection handle.
+    """
+    return serial.Serial(port=args.serial_device, timeout=0.2, baudrate=115200,)
+
 def main():
     """
     Entry point of the application.
@@ -164,7 +172,7 @@ def main():
     with open(args.binary_file, 'rb') as input_file:
         binary = input_file.read()
 
-    serial_port = serial.Serial(args.serial_device, baudrate=115200, timeout=0.2)
+    serial_port = open_connection(args)
 
     print("Flashing firmware (size: {} bytes)".format(len(binary)))
     flash_binary(serial_port, binary, args.base_address, args.device_class, args.ids)

--- a/client/bootloader_flash.py
+++ b/client/bootloader_flash.py
@@ -29,15 +29,23 @@ def parse_commandline_args(args=None):
                         type=lambda s: int(s, 16)) # automatically convert value to hex
 
     parser.add_argument('-p', '--port', dest='serial_device',
-                        required=True,
                         help='Serial port to which the CAN port is connected to.',
                         metavar='DEVICE')
+
+    parser.add_argument('--tcp', dest='hostname', help="Use TCP/IP instead of serial port (host:port format).", metavar="HOST")
 
     parser.add_argument('-c', '--device-class', dest='device_class', help='Device class to flash', required=True)
     parser.add_argument('-r', '--run', help='Run application after flashing', action='store_true')
     parser.add_argument("ids", metavar='DEVICEID', nargs='+', type=int, help="Device IDs to flash")
 
-    return parser.parse_args(args)
+
+    args = parser.parse_args(args)
+
+    if args.hostname is None and args.serial_device is None:
+        parser.error("You must specify one of --tcp or --port")
+
+    return args
+
 
 def write_command(fdesc, command, destinations, source=0):
     """

--- a/client/bootloader_flash.py
+++ b/client/bootloader_flash.py
@@ -44,6 +44,9 @@ def parse_commandline_args(args=None):
     if args.hostname is None and args.serial_device is None:
         parser.error("You must specify one of --tcp or --port")
 
+    if args.hostname and args.serial_device:
+        parser.error("Can only use one of--tcp and --port")
+
     return args
 
 

--- a/client/bootloader_flash.py
+++ b/client/bootloader_flash.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import argparse
+import socket
 import page
 import commands
 import serial_datagrams, can, can_bridge
@@ -162,7 +163,19 @@ def open_connection(args):
 
     Returns a file like object which will be the connection handle.
     """
-    return serial.Serial(port=args.serial_device, timeout=0.2, baudrate=115200,)
+    if args.serial_device:
+        return serial.Serial(port=args.serial_device, timeout=0.2, baudrate=115200)
+
+    elif args.hostname:
+        try:
+            host, port = args.hostname.split(":")
+        except ValueError:
+            host, port = args.hostname, 1337
+
+        port = int(port)
+
+        connection = socket.create_connection((host, port))
+        return connection.makefile('w+b')
 
 def main():
     """

--- a/client/tests/test_flashtool.py
+++ b/client/tests/test_flashtool.py
@@ -384,7 +384,7 @@ class ArgumentParsingTestCase(unittest.TestCase):
             parse_commandline_args(commandline.split())
 
             # Checked that we printed some kind of error
-            error.assert_any_call(unittest.mock.ANY)
+            error.assert_any_call(ANY)
 
     def test_network_hostname_or_serial_are_exclusive(self):
         """
@@ -396,7 +396,7 @@ class ArgumentParsingTestCase(unittest.TestCase):
             parse_commandline_args(commandline.split())
 
             # Checked that we printed some kind of error
-            error.assert_any_call(unittest.mock.ANY)
+            error.assert_any_call(ANY)
 
 class OpenConnectionTestCase(unittest.TestCase):
     Args = namedtuple("Args", ["hostname", "serial_device"])

--- a/client/tests/test_flashtool.py
+++ b/client/tests/test_flashtool.py
@@ -416,3 +416,32 @@ class OpenConnectionTestCase(unittest.TestCase):
 
             self.assertEqual(port, serial.return_value)
             serial.assert_any_call(port="/dev/ttyUSB0", baudrate=ANY, timeout=ANY)
+
+    def test_open_hostname_default_port(self):
+        """
+        Checks that we can open a connection to a hostname with the default port.
+        """
+        args = self.make_args(hostname="10.0.0.10")
+
+        with patch('socket.create_connection') as create_connection:
+            socket = Mock()
+            socket.makefile = Mock(return_value=object())
+
+            create_connection.return_value = socket
+            port = open_connection(args)
+
+            create_connection.assert_any_call(('10.0.0.10', 1337))
+
+            # Check that we converted the socket to a read-write binary file object
+            socket.makefile.assert_any_call('w+b')
+
+            self.assertEqual(port, socket.makefile.return_value)
+
+    def test_open_hostname_custom_port(self):
+        """
+        Checks if we can open a connection to a hostname on a different port.
+        """
+        args = self.make_args(hostname="10.0.0.10:42")
+        with patch('socket.create_connection') as create_connection:
+            port = open_connection(args)
+            create_connection.assert_any_call(('10.0.0.10', 42))

--- a/client/tests/test_flashtool.py
+++ b/client/tests/test_flashtool.py
@@ -10,6 +10,7 @@ from zlib import crc32
 
 from bootloader_flash import *
 from commands import *
+from collections import namedtuple
 import msgpack
 
 from io import BytesIO
@@ -398,13 +399,16 @@ class ArgumentParsingTestCase(unittest.TestCase):
             error.assert_any_call(unittest.mock.ANY)
 
 class OpenConnectionTestCase(unittest.TestCase):
-    DEFAULT_COMMANDLINE = " -b test.bin -a 0x1000 -c dummy 1 2"
+    Args = namedtuple("Args", ["hostname", "serial_device"])
+
+    def make_args(self, hostname=None, serial_device=None):
+        return self.Args(hostname=hostname, serial_device=serial_device)
+
     def test_open_serial(self):
         """
         Checks that if we provide a serial port the serial port is
         """
-        commandline = "-p /dev/ttyUSB0" + self.DEFAULT_COMMANDLINE
-        args = parse_commandline_args(commandline.split())
+        args = self.make_args(serial_device='/dev/ttyUSB0')
 
         with patch('serial.Serial') as serial:
             serial.return_value = object()

--- a/client/tests/test_flashtool.py
+++ b/client/tests/test_flashtool.py
@@ -293,7 +293,7 @@ class MainTestCase(unittest.TestCase):
         Checks that we open the correct serial port to the bridge.
         """
         main()
-        self.serial.assert_any_call('/dev/ttyUSB0', baudrate=115200, timeout=0.2)
+        self.serial.assert_any_call(port='/dev/ttyUSB0', baudrate=115200, timeout=0.2)
 
     def test_flash_binary(self):
         """
@@ -396,3 +396,19 @@ class ArgumentParsingTestCase(unittest.TestCase):
 
             # Checked that we printed some kind of error
             error.assert_any_call(unittest.mock.ANY)
+
+class OpenConnectionTestCase(unittest.TestCase):
+    DEFAULT_COMMANDLINE = " -b test.bin -a 0x1000 -c dummy 1 2"
+    def test_open_serial(self):
+        """
+        Checks that if we provide a serial port the serial port is
+        """
+        commandline = "-p /dev/ttyUSB0" + self.DEFAULT_COMMANDLINE
+        args = parse_commandline_args(commandline.split())
+
+        with patch('serial.Serial') as serial:
+            serial.return_value = object()
+            port = open_connection(args)
+
+            self.assertEqual(port, serial.return_value)
+            serial.assert_any_call(port="/dev/ttyUSB0", baudrate=ANY, timeout=ANY)

--- a/client/tests/test_flashtool.py
+++ b/client/tests/test_flashtool.py
@@ -384,3 +384,15 @@ class ArgumentParsingTestCase(unittest.TestCase):
 
             # Checked that we printed some kind of error
             error.assert_any_call(unittest.mock.ANY)
+
+    def test_network_hostname_or_serial_are_exclusive(self):
+        """
+        Checks that the serial device and the TCP/IP host are mutually exclusive.
+        """
+        commandline = "-b test.bin -a 0x1000 -p /dev/ttyUSB0 --tcp 10.0.0.10 --run -c dummy 1 2 3"
+
+        with patch('argparse.ArgumentParser.error') as error:
+            parse_commandline_args(commandline.split())
+
+            # Checked that we printed some kind of error
+            error.assert_any_call(unittest.mock.ANY)

--- a/client/tests/test_flashtool.py
+++ b/client/tests/test_flashtool.py
@@ -363,3 +363,24 @@ class ArgumentParsingTestCase(unittest.TestCase):
         self.assertEqual('dummy', args.device_class)
         self.assertEqual([1,2,3], args.ids)
         self.assertTrue(args.run)
+
+    def test_network_hostname(self):
+        """
+        Checks that we can pass a hostname
+        """
+        commandline = "-b test.bin -a 0x1000 --tcp 10.0.0.10 --run -c dummy 1 2 3"
+        args = parse_commandline_args(commandline.split())
+        self.assertEqual(None, args.serial_device)
+        self.assertEqual("10.0.0.10", args.hostname)
+
+    def test_network_hostname_or_serial_is_required(self):
+        """
+        Checks that we have either a serial device or a TCP/IP host to use.
+        """
+        commandline = "-b test.bin -a 0x1000 --run -c dummy 1 2 3"
+
+        with patch('argparse.ArgumentParser.error') as error:
+            parse_commandline_args(commandline.split())
+
+            # Checked that we printed some kind of error
+            error.assert_any_call(unittest.mock.ANY)


### PR DESCRIPTION
This pull request implements the support for flashing the robot over a TCP/IP CAN bridge instead of just UART CAN. This should allow us to update the robot via wireless.
