### PR TITLE
Add return values to critical commands.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -84,12 +84,12 @@ They should simply send the MessagePack encoded response on the bus.
 
 1. Jump to application (0x01). No parameters. Simply starts the application code.
 2. CRC flash region (0x02). 2 parameters : start adress and length of the region we want to check. Returns the CRC32 of this region.
-3. Erase flash page (0x03). Parameters : Page address, device class (string). Returns nothing.
-4. Write flash (0x04). Parameters : Start adress, device class (string) and sequence of bytes to write. Returns nothing.
+3. Erase flash page (0x03). Parameters : Page address, device class (string). Returns: True if successful.
+4. Write flash (0x04). Parameters : Start adress, device class (string) and sequence of bytes to write. Returns: True if successful.
 5. Ping (0x05). Parameters: None. Returns: True if bootloader is ready to accept a command.
 6. Read flash (0x06). Parameters : Start adress and length. Returns sequence of read bytes
-7. Update config (0x07). The only parameters is a MessagePack map containing the configuration values to update. If a config value is not in its parameters, it will not be changed.
-8. Save config to flash.
+7. Update config (0x07). The only parameters is a MessagePack map containing the configuration values to update. If a config value is not in its parameters, it will not be changed. Returns: True if successful.
+8. Save config to flash (0x08). Returns: True if successful.
 9. Read current config (0x09). No parameters. Writes back a messagepack map containing the bootloader config.
 
 *Note:* Adresses (pointers) in the arguments are represented as 64 bits integers.
@@ -98,10 +98,11 @@ They should simply send the MessagePack encoded response on the bus.
 ## Multicast write
 When using multicast write the recommended way is the following :
 
-1. Write to all board using multicast write command (0x04).
-2. Wait for one board to reply with 'True'
-3. Poll every board write status, wait until every board has finished.
-4. Ask each board to compute the CRC of the page you just wrote. If a board is wrong, reflash just this one.
+1. Write to all boards using multicast write command.
+2. Wait with a timeout for the command to finish.
+3. Continue only with boards that successfully finished.
+4. Verify the written data via CRC command.
+5. Reflash the boards that failed during above process. (optional)
 
 # Flash layout
 The bootloader resides in the N flash pages.

--- a/command.c
+++ b/command.c
@@ -10,7 +10,7 @@
 void command_erase_flash_page(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloader_config_t *config)
 {
     void *address;
-    uint64_t tmp;
+    uint64_t tmp = 0;
     char device_class[64];
 
     cmp_read_uinteger(args, &tmp);
@@ -46,7 +46,7 @@ void command_write_flash(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloader_c
 {
     void *address;
     void *src;
-    uint64_t tmp;
+    uint64_t tmp = 0;
     uint32_t size;
     char device_class[64];
 

--- a/command.c
+++ b/command.c
@@ -18,16 +18,14 @@ void command_erase_flash_page(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloa
 
     // refuse to overwrite bootloader or config pages
     if (address < memory_get_app_addr()) {
-        cmp_write_bool(out, 0);
-        return;
+        goto command_fail;
     }
 
     uint32_t size = 64;
     cmp_read_str(args, device_class, &size);
 
     if (strcmp(device_class, config->device_class) != 0) {
-        cmp_write_bool(out, 0);
-        return;
+        goto command_fail;
     }
 
     flash_writer_unlock();
@@ -37,6 +35,11 @@ void command_erase_flash_page(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloa
     flash_writer_lock();
 
     cmp_write_bool(out, 1);
+    return;
+
+command_fail:
+    cmp_write_bool(out, 0);
+    return;
 }
 
 void command_write_flash(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloader_config_t *config)
@@ -52,20 +55,18 @@ void command_write_flash(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloader_c
 
     // refuse to overwrite bootloader or config pages
     if (address < memory_get_app_addr()) {
-        cmp_write_bool(out, 0);
-        return;
+        goto command_fail;
     }
 
     size = 64;
     cmp_read_str(args, device_class, &size);
 
     if (strcmp(device_class, config->device_class) != 0) {
-        cmp_write_bool(out, 0);
-        return;
+        goto command_fail;
     }
 
     if (!cmp_read_bin_size(args, &size)) {
-        return;
+        goto command_fail;
     }
 
     /* This is ugly, yet required to achieve zero copy. */
@@ -78,6 +79,11 @@ void command_write_flash(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloader_c
     flash_writer_lock();
 
     cmp_write_bool(out, 1);
+    return;
+
+command_fail:
+    cmp_write_bool(out, 0);
+    return;
 }
 
 void command_read_flash(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloader_config_t *config)

--- a/command.c
+++ b/command.c
@@ -18,6 +18,7 @@ void command_erase_flash_page(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloa
 
     // refuse to overwrite bootloader or config pages
     if (address < memory_get_app_addr()) {
+        cmp_write_bool(out, 0);
         return;
     }
 
@@ -25,6 +26,7 @@ void command_erase_flash_page(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloa
     cmp_read_str(args, device_class, &size);
 
     if (strcmp(device_class, config->device_class) != 0) {
+        cmp_write_bool(out, 0);
         return;
     }
 
@@ -33,6 +35,8 @@ void command_erase_flash_page(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloa
     flash_writer_page_erase(address);
 
     flash_writer_lock();
+
+    cmp_write_bool(out, 1);
 }
 
 void command_write_flash(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloader_config_t *config)
@@ -48,6 +52,7 @@ void command_write_flash(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloader_c
 
     // refuse to overwrite bootloader or config pages
     if (address < memory_get_app_addr()) {
+        cmp_write_bool(out, 0);
         return;
     }
 
@@ -55,6 +60,7 @@ void command_write_flash(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloader_c
     cmp_read_str(args, device_class, &size);
 
     if (strcmp(device_class, config->device_class) != 0) {
+        cmp_write_bool(out, 0);
         return;
     }
 
@@ -70,6 +76,8 @@ void command_write_flash(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloader_c
     flash_writer_page_write(address, src, size);
 
     flash_writer_lock();
+
+    cmp_write_bool(out, 1);
 }
 
 void command_read_flash(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloader_config_t *config)
@@ -113,6 +121,7 @@ void command_crc_region(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloader_co
 void command_config_update(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloader_config_t *config)
 {
     config_update_from_serialized(config, args);
+    cmp_write_bool(out, 1);
 }
 
 void command_ping(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloader_config_t *config)
@@ -141,19 +150,29 @@ void command_config_write_to_flash(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bo
     void *config1 = memory_get_config1_addr();
     void *config2 = memory_get_config2_addr();
 
+    bool success = false;
+
     if (block_crc_verify(config2, CONFIG_PAGE_SIZE)) {
         if (flash_write_and_verify(config1, config_page_buffer, CONFIG_PAGE_SIZE)) {
-            flash_write_and_verify(config2, config_page_buffer, CONFIG_PAGE_SIZE);
+            if (flash_write_and_verify(config2, config_page_buffer, CONFIG_PAGE_SIZE)) {
+                success = true;
+            }
         }
-        return;
     } else if (block_crc_verify(config1, CONFIG_PAGE_SIZE)) {
         if (flash_write_and_verify(config2, config_page_buffer, CONFIG_PAGE_SIZE)) {
-            flash_write_and_verify(config1, config_page_buffer, CONFIG_PAGE_SIZE);
+            if (flash_write_and_verify(config1, config_page_buffer, CONFIG_PAGE_SIZE)) {
+                success = true;
+            }
         }
-        return;
     } else {
-            flash_write_and_verify(config1, config_page_buffer, CONFIG_PAGE_SIZE);
-            flash_write_and_verify(config2, config_page_buffer, CONFIG_PAGE_SIZE);
+        success = flash_write_and_verify(config1, config_page_buffer, CONFIG_PAGE_SIZE);
+        success &= flash_write_and_verify(config2, config_page_buffer, CONFIG_PAGE_SIZE);
+    }
+
+    if (success) {
+        cmp_write_bool(out, 1);
+    } else {
+        cmp_write_bool(out, 0);
     }
 }
 

--- a/config.c
+++ b/config.c
@@ -76,7 +76,7 @@ bootloader_config_t config_read(void *buffer, size_t buffer_size)
 
 void config_update_from_serialized(bootloader_config_t *config, cmp_ctx_t *context)
 {
-    uint32_t key_count;
+    uint32_t key_count = 0;
     char key[64];
     uint32_t key_len;
 

--- a/tests/config_commands_tests.cpp
+++ b/tests/config_commands_tests.cpp
@@ -5,6 +5,7 @@
 
 #include "../flash_writer.h"
 #include "../command.h"
+#include "mocks/platform_mock.h"
 
 
 TEST_GROUP(ConfigCommandTestGroup)
@@ -39,9 +40,14 @@ TEST(ConfigCommandTestGroup, CanChangeNodeID)
     cmp_write_str(&command_builder, "ID", 2);
     cmp_write_u8(&command_builder, 42);
 
-    command_config_update(1, &command_builder, NULL, &config);
+    command_config_update(1, &command_builder, &output_ctx, &config);
 
     CHECK_EQUAL(42, config.ID);
+
+    // check return value
+    bool ret = false;
+    cmp_read_bool(&output_ctx, &ret);
+    CHECK_TRUE(ret);
 }
 
 TEST(ConfigCommandTestGroup, CanReadConfig)

--- a/tests/flash_command_tests.cpp
+++ b/tests/flash_command_tests.cpp
@@ -17,11 +17,19 @@ TEST_GROUP(FlashCommandTestGroup)
     char page[1024];
     bootloader_config_t config;
 
+    char out_data[32];
+    serializer_t out_serializer;
+    cmp_ctx_t out;
+
     void setup()
     {
         serializer_init(&serializer, command_data, sizeof command_data);
         serializer_cmp_ctx_factory(&command_builder, &serializer);
         memset(command_data, 0, sizeof command_data);
+
+        serializer_init(&out_serializer, out_data, sizeof out_data);
+        serializer_cmp_ctx_factory(&out, &out_serializer);
+        memset(out_data, 0, sizeof out_data);
 
         // Creates a dummy device class for testing
         strcpy(config.device_class, "test.dummy");
@@ -53,18 +61,28 @@ TEST(FlashCommandTestGroup, CanFlashSinglePage)
                  .withPointerParameter("page_adress", page)
                  .withIntParameter("size", strlen(data));
 
-    command_write_flash(1, &command_builder, NULL, &config);
+    command_write_flash(1, &command_builder, &out, &config);
 
     mock().checkExpectations();
     STRCMP_EQUAL(data, page);
+
+    // check return value
+    bool ret = false;
+    cmp_read_bool(&out, &ret);
+    CHECK_TRUE(ret);
 }
 
 TEST(FlashCommandTestGroup, CheckErrorHandlingWithIllFormatedArguments)
 {
     // We simply check that no mock flash operation occurs
-    command_write_flash(1, &command_builder, NULL, &config);
+    command_write_flash(1, &command_builder, &out, &config);
 
     mock().checkExpectations();
+
+    // check return value
+    bool ret = true;
+    cmp_read_bool(&out, &ret);
+    CHECK_FALSE(ret);
 }
 
 TEST(FlashCommandTestGroup, CheckThatDeviceClassIsRespected)
@@ -81,9 +99,14 @@ TEST(FlashCommandTestGroup, CheckThatDeviceClassIsRespected)
 
     // Executes the command. Since the device class mismatch it should not make
     // any write
-    command_write_flash(1, &command_builder, NULL, &config);
+    command_write_flash(1, &command_builder, &out, &config);
 
     mock().checkExpectations();
+
+    // check return value
+    bool ret = true;
+    cmp_read_bool(&out, &ret);
+    CHECK_FALSE(ret);
 }
 
 TEST(FlashCommandTestGroup, CanErasePage)
@@ -101,9 +124,14 @@ TEST(FlashCommandTestGroup, CanErasePage)
 
     mock("flash").expectOneCall("page_erase").withPointerParameter("adress", &page);
 
-    command_erase_flash_page(1, &command_builder, NULL, &config);
+    command_erase_flash_page(1, &command_builder, &out, &config);
 
     mock().checkExpectations();
+
+    // check return value
+    bool ret = false;
+    cmp_read_bool(&out, &ret);
+    CHECK_TRUE(ret);
 }
 
 TEST(FlashCommandTestGroup, DeviceClassIsRespectedForErasePage)
@@ -111,19 +139,29 @@ TEST(FlashCommandTestGroup, DeviceClassIsRespectedForErasePage)
     // Writes the adress of the page
     cmp_write_u64(&command_builder, (size_t)&page);
 
-    // Writes the correct device class
+    // Writes the wrong device class
     cmp_write_str(&command_builder, "fail", 4);
 
-    command_erase_flash_page(1, &command_builder, NULL, &config);
+    command_erase_flash_page(1, &command_builder, &out, &config);
 
     mock().checkExpectations();
+
+    // check return value
+    bool ret = true;
+    cmp_read_bool(&out, &ret);
+    CHECK_FALSE(ret);
 }
 
 TEST(FlashCommandTestGroup, CheckIllFormatedArgumentsForErasePage)
 {
-    command_erase_flash_page(1, &command_builder, NULL, &config);
+    command_erase_flash_page(1, &command_builder, &out, &config);
 
     mock().checkExpectations();
+
+    // check return value
+    bool ret = true;
+    cmp_read_bool(&out, &ret);
+    CHECK_FALSE(ret);
 }
 
 TEST_GROUP(JumpToApplicationCodetestGroup)


### PR DESCRIPTION
While testing the bootloader we were getting too little feedback about the flashing progress from client and bootloader.
To address this, I propose we a add a return value to commands changing the flash or the config. This improves flashing time and lets the client know if the command was successful. I think this is better than polling via the ping command.
This is easily implemented on the bootloader side. For the client however, it is a bit more difficult, but we need to improve datagram reception anyway (adding filter & timeouts).
