### PR TITLE
Add a tool to change the node ID

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -29,8 +29,9 @@ These are the tools for talking with the bootloader on the host.
 They can all run with `-h/--help`, so use that to know how arguments works.
 
 * `bootloader_flash.py`: Used to program target boards.
-* `bootloader_write_config.py`: Used to change board config, such as device class, ID and so on. *Use it carefully.*
 * `bootloader_read_config.py`: Used to read the config from a bunch of boards and dump it as JSON.
+* `bootloader_change_id.py`: Used to change a single device ID *Use it carefully.*
+* `bootloader_write_config.py`: Used to change board config, such as device class, name and so on.
 
 # Code organization
 

--- a/client/bootloader_change_id.py
+++ b/client/bootloader_change_id.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+import utils
+import commands
+
+def parse_commandline_args():
+    parser = utils.ConnectionArgumentParser(description='Change a single node ID.')
+    parser.add_argument("old", type=int, help="Old device ID")
+    parser.add_argument("new", type=int, help="New device ID")
+
+    return parser.parse_args()
+
+def main():
+    args = parse_commandline_args()
+    connection = utils.open_connection(args)
+
+    config = {"ID": args.new}
+    utils.write_command(connection, commands.encode_update_config(config), [args.old])
+    utils.write_command(connection, commands.encode_save_config(), [args.new])
+
+if __name__ == "__main__":
+    main()

--- a/client/bootloader_write_config.py
+++ b/client/bootloader_write_config.py
@@ -25,8 +25,14 @@ def parse_commandline_args():
 
 def main():
     args = parse_commandline_args()
-    connection = utils.open_connection(args)
     config = json.loads(args.file.read())
+
+    if "ID" in config.keys():
+        print("This tool cannot be used to change node IDs.")
+        print("Use bootloader_change_id.py instead.")
+        sys.exit(1)
+
+    connection = utils.open_connection(args)
     utils.config_update_and_save(connection, config, args.ids)
 
 if __name__ == "__main__":

--- a/client/tests/test_change_id_tool.py
+++ b/client/tests/test_change_id_tool.py
@@ -1,0 +1,26 @@
+import unittest
+
+try:
+    from unittest.mock import *
+except ImportError:
+    from mock import *
+
+import sys
+import bootloader_change_id
+import commands
+
+class BootloaderChangeIdTestCase(unittest.TestCase):
+    @patch('utils.write_command')
+    @patch('serial.Serial')
+    def test_integration(self, serial, write_command):
+        sys.argv = "test.py -p /dev/ttyUSB0 1 2".split()
+        serial.return_value = object()
+
+        bootloader_change_id.main()
+        serial.assert_any_call(port='/dev/ttyUSB0', timeout=ANY, baudrate=ANY)
+
+        command = commands.encode_update_config({'ID':2})
+        write_command.assert_any_call(serial.return_value, command, [1])
+
+        command = commands.encode_save_config()
+        write_command.assert_any_call(serial.return_value, command, [2])

--- a/client/tests/test_config_write_tool.py
+++ b/client/tests/test_config_write_tool.py
@@ -26,9 +26,16 @@ class WriteConfigToolTestCase(unittest.TestCase):
         serial.assert_any_call(port='/dev/ttyUSB0', timeout=ANY, baudrate=ANY)
         config_save.assert_any_call(serial.return_value, {'foo':12}, [1, 2, 3])
 
+    @patch('builtins.open')
+    @patch('builtins.print')
+    def test_fails_on_ID_change(self, print_mock, open_mock):
+        """
+        Checks that this tool refuses to change a Node ID.
+        """
+        sys.argv = "test.py -c nonexisting.json -p /dev/ttyUSB0 1 2 3".split()
+        config_file = '{"ID":11}'
 
+        open_mock.return_value = StringIO(config_file)
 
-
-
-
-
+        with self.assertRaises(SystemExit):
+            bootloader_write_config.main()


### PR DESCRIPTION
I thought it was pretty dangerous to use the config write tool to change node IDs, since it allowed multicast write, which can lead to ID collision. Plus the tool needed to be run twice, since it would not execute the flash write command since it changed its ID in the meantime.

My suggested solution is to extract this functionality into its own utility, mark it as explicitly dangerous, and only allow it to change one node ID at the time.
