### PR TITLE
Use source ID in receive mechanism (allow for broadcast)

### DIFF
--- a/client/bootloader_flash.py
+++ b/client/bootloader_flash.py
@@ -98,7 +98,9 @@ def crc_region(fdesc, base_address, length, destination):
     """
     command = commands.encode_crc_region(base_address, length)
     utils.write_command(fdesc, command, [destination])
-    answer, _ = utils.read_can_datagram(fdesc)
+
+    reader = utils.CANDatagramReader(fdesc)
+    answer, _, _ = reader.read_datagram()
 
     return msgpack.unpackb(answer)
 

--- a/client/bootloader_read_config.py
+++ b/client/bootloader_read_config.py
@@ -23,9 +23,11 @@ def main():
 
     configs = dict()
 
+    reader = utils.CANDatagramReader(connection)
+
     for id in args.ids:
         utils.write_command(connection, commands.encode_read_config(), [id])
-        answer, _ = utils.read_can_datagram(connection)
+        answer, _, _ = reader.read_datagram()
         configs[id] = msgpack.unpackb(answer, encoding='ascii')
 
     print(json.dumps(configs, indent=4, sort_keys=True))

--- a/client/bootloader_read_config.py
+++ b/client/bootloader_read_config.py
@@ -25,10 +25,12 @@ def main():
 
     reader = utils.CANDatagramReader(connection)
 
+    # Broadcast ask for config
+    utils.write_command(connection, commands.encode_read_config(), args.ids)
+
     for id in args.ids:
-        utils.write_command(connection, commands.encode_read_config(), [id])
-        answer, _, _ = reader.read_datagram()
-        configs[id] = msgpack.unpackb(answer, encoding='ascii')
+        answer, _, src = reader.read_datagram()
+        configs[src] = msgpack.unpackb(answer, encoding='ascii')
 
     print(json.dumps(configs, indent=4, sort_keys=True))
 

--- a/client/tests/test_config_read_tool.py
+++ b/client/tests/test_config_read_tool.py
@@ -12,8 +12,8 @@ from commands import *
 import sys
 import json
 
-class WriteConfigToolTestCase(unittest.TestCase):
-    @patch('utils.read_can_datagram')
+class ReadConfigToolTestCase(unittest.TestCase):
+    @patch('utils.CANDatagramReader.read_datagram')
     @patch('utils.write_command')
     @patch('serial.Serial')
     @patch('builtins.print')
@@ -21,7 +21,7 @@ class WriteConfigToolTestCase(unittest.TestCase):
         sys.argv = "test.py -p /dev/ttyUSB0 0 1 2".split()
         configs = [{'id':i} for i in range(3)]
 
-        read_can_datagram.side_effect = [(packb(c), 0) for c in configs]
+        read_can_datagram.side_effect = [(packb(c), 0, 0) for c in configs]
 
         serial.return_value = object()
 
@@ -31,7 +31,7 @@ class WriteConfigToolTestCase(unittest.TestCase):
 
         for i in range(3):
             write_command.assert_any_call(serial.return_value, encode_read_config(), [i])
-            read_can_datagram.assert_any_call(serial.return_value)
+            read_can_datagram.assert_any_call()
 
         all_configs = {i:configs[i] for i in range(3)}
 

--- a/client/tests/test_flashtool.py
+++ b/client/tests/test_flashtool.py
@@ -118,7 +118,7 @@ class CANDatagramReadTestCase(unittest.TestCase):
         data = can.encode_datagram(data, destinations=[1])
 
         # Slice the datagram in frames
-        frames = can.datagram_to_frames(data, source=0)
+        frames = can.datagram_to_frames(data, source=42)
 
         # Serializes CAN frames for the bridge
         frames = [can_bridge.encode_frame(f) for f in frames]
@@ -129,11 +129,14 @@ class CANDatagramReadTestCase(unittest.TestCase):
         # Put all data in a pseudofile
         fdesc = BytesIO(frames)
 
+        reader = CANDatagramReader(fdesc)
+
         # Read a CAN datagram from that pseudofile
-        dt, dst = read_can_datagram(fdesc)
+        dt, dst, src = reader.read_datagram()
 
         self.assertEqual(dt.decode('ascii'), 'Hello world')
         self.assertEqual(dst, [1])
+        self.assertEqual(src, 42)
 
     def test_read_can_interleaved_datagrams(self):
         """
@@ -184,9 +187,11 @@ class CANDatagramReadTestCase(unittest.TestCase):
         # Packs each frame in a serial datagram
         frames = [serial_datagrams.datagram_encode(f) for f in frames]
 
+        reader = CANDatagramReader(None)
+
         with patch('serial_datagrams.read_datagram') as read:
             read.side_effect = [None] + frames
-            dt, dst = read_can_datagram(None)
+            dt, dst, _ = reader.read_datagram()
 
         self.assertEqual(dt.decode('ascii'), 'Hello world')
         self.assertEqual(dst, [1])
@@ -216,28 +221,25 @@ class CrcRegionTestCase(unittest.TestCase):
     fd = 'port'
 
     @patch('utils.write_command')
-    @patch('utils.read_can_datagram')
+    @patch('utils.CANDatagramReader.read_datagram')
     def test_read_crc_sends_command(self, read, write):
         """
         Checks that a CRC read sends the correct command.
         """
-        read.return_value = (msgpack.packb(0xdeadbeef), [1])
+        read.return_value = (msgpack.packb(0xdeadbeef), [1], 0)
 
         crc_region(fdesc=self.fd, base_address=0x1000, length=100, destination=42)
         command = commands.encode_crc_region(0x1000, 100)
         write.assert_any_call(self.fd, command, [42])
 
     @patch('utils.write_command')
-    @patch('utils.read_can_datagram')
+    @patch('utils.CANDatagramReader.read_datagram')
     def test_read_crc_answer(self, read, write):
         """
         Checks that we can read back the CRC answer.
         """
-        read.return_value = (msgpack.packb(0xdeadbeef), [1])
+        read.return_value = (msgpack.packb(0xdeadbeef), [1], 0)
         crc = crc_region(fdesc=self.fd, base_address=0x1000, length=100, destination=42)
-
-        # Checks that the port was given correctly
-        read.assert_any_call(self.fd)
 
         # Checks that the CRC value matches the expected one
         self.assertEqual(0xdeadbeef, crc)

--- a/client/utils.py
+++ b/client/utils.py
@@ -90,28 +90,6 @@ class CANDatagramReader:
 
         return data, dst, src
 
-
-
-
-
-def read_can_datagram(fdesc):
-    """
-    Reads a full CAN datagram from the CAN <-> serial bridge.
-    """
-    buf = bytes()
-    datagram = None
-
-    while datagram is None:
-        frame = serial_datagrams.read_datagram(fdesc)
-        if frame is None: # Timeout, retry
-            continue
-        frame = can_bridge.decode_frame(frame)
-        buf += frame.data
-        datagram = can.decode_datagram(buf)
-
-    return datagram
-
-
 def write_command(fdesc, command, destinations, source=0):
     """
     Writes the given encoded command to the CAN bridge.

--- a/client/utils.py
+++ b/client/utils.py
@@ -7,6 +7,7 @@ import commands
 import can
 import can_bridge
 import serial_datagrams
+from collections import defaultdict
 
 class ConnectionArgumentParser(argparse.ArgumentParser):
     """
@@ -54,6 +55,43 @@ def open_connection(args):
 
         connection = socket.create_connection((host, port))
         return connection.makefile('wrb')
+
+class CANDatagramReader:
+    """
+    This class implements CAN datagram reading.
+
+    It supports reading interleaved datagrams through internal buffering.
+    """
+    def __init__(self, fdesc):
+        self.fdesc = fdesc
+        self.buf = defaultdict(lambda: bytes())
+
+    def read_datagram(self):
+        """
+        Reads a single datagram.
+        """
+        datagram = None
+
+        while datagram is None:
+            frame = serial_datagrams.read_datagram(self.fdesc)
+            if frame is None: # Timeout, retry
+                continue
+
+            frame = can_bridge.decode_frame(frame)
+
+            src = frame.id & (0x7f)
+
+            self.buf[src] += frame.data
+
+            datagram = can.decode_datagram(self.buf[src])
+
+            if datagram is not None:
+                data, dst = datagram
+
+        return data, dst, src
+
+
+
 
 
 def read_can_datagram(fdesc):


### PR DESCRIPTION
So after discussing this afternoon I decided to try to implement the interleaved datagram reading. It seems to work, but I would like to test it on real hardware soon.

It should allow us to use broadcast to be more effective.
