### PR TITLE
Rename reboot to reboot_system

### DIFF
--- a/boot_arg.h
+++ b/boot_arg.h
@@ -12,7 +12,7 @@ extern "C" {
 #define BOOT_ARG_START_APPLICATION              0x02
 #define BOOT_ARG_START_ST_BOOTLOADER            0x03
 
-void reboot(uint8_t arg);
+void reboot_system(uint8_t arg);
 
 #ifdef __cplusplus
 }

--- a/command.c
+++ b/command.c
@@ -104,9 +104,9 @@ void command_read_flash(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloader_co
 void command_jump_to_application(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloader_config_t *config)
 {
     if (crc32(0, memory_get_app_addr(), config->application_size) == config->application_crc) {
-        reboot(BOOT_ARG_START_APPLICATION);
+        reboot_system(BOOT_ARG_START_APPLICATION);
     } else {
-        reboot(BOOT_ARG_START_BOOTLOADER_NO_TIMEOUT);
+        reboot_system(BOOT_ARG_START_BOOTLOADER_NO_TIMEOUT);
     }
 }
 

--- a/platform/mcu/armv7-m/boot_arg.c
+++ b/platform/mcu/armv7-m/boot_arg.c
@@ -5,7 +5,7 @@
 #define BOOT_ARG_MAGIC_VALUE_LO 0x01234567
 #define BOOT_ARG_MAGIC_VALUE_HI 0x0089abcd
 
-void reboot(uint8_t arg)
+void reboot_system(uint8_t arg)
 {
     uint32_t *ram_start = (uint32_t *)0x20000000;
 

--- a/platform/motor-board-v1/platform.c
+++ b/platform/motor-board-v1/platform.c
@@ -54,7 +54,7 @@ void can_interface_init(void)
 void fault_handler(void)
 {
     // while(1); // debug
-    reboot(BOOT_ARG_START_BOOTLOADER_NO_TIMEOUT);
+    reboot_system(BOOT_ARG_START_BOOTLOADER_NO_TIMEOUT);
 }
 
 typedef struct {
@@ -152,5 +152,5 @@ void platform_main(int arg)
 
     bootloader_main(arg);
 
-    reboot(BOOT_ARG_START_BOOTLOADER);
+    reboot_system(BOOT_ARG_START_BOOTLOADER);
 }

--- a/platform/rc-board-v1/platform.c
+++ b/platform/rc-board-v1/platform.c
@@ -61,7 +61,7 @@ void fault_handler(void)
 
     while(1); // debug
 
-    reboot(BOOT_ARG_START_BOOTLOADER_NO_TIMEOUT);
+    reboot_system(BOOT_ARG_START_BOOTLOADER_NO_TIMEOUT);
 }
 
 typedef struct {
@@ -149,5 +149,5 @@ void platform_main(int arg)
 
     bootloader_main(arg);
 
-    reboot(BOOT_ARG_START_BOOTLOADER);
+    reboot_system(BOOT_ARG_START_BOOTLOADER);
 }

--- a/tests/mocks/boot_arg.cpp
+++ b/tests/mocks/boot_arg.cpp
@@ -5,7 +5,7 @@ extern "C" {
 #include "../../boot_arg.h"
 }
 
-void reboot(uint8_t arg)
+void reboot_system(uint8_t arg)
 {
     mock().actualCall("reboot").withIntParameter("arg", arg);
 }


### PR DESCRIPTION
reboot(2) is a system call on BSD/OSX/Linux. This means that it is defined in unistd.h. This in turn means that the build fails if we define a function with the same name.

Discovered this while trying to rebuild the project to do integration testing between Python and C. I guess the build breaking is due to updating CppUTest on my system.

@nuft @Stapelzeiger ok for you ?
