### PR TITLE
Do not write past end of flash

### DIFF
--- a/command.c
+++ b/command.c
@@ -21,6 +21,11 @@ void command_erase_flash_page(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloa
         goto command_fail;
     }
 
+    // Refuse to erase past end of flash memory
+    if (address >= memory_get_app_addr() + memory_get_app_size()) {
+        goto command_fail;
+    }
+
     uint32_t size = 64;
     cmp_read_str(args, device_class, &size);
 
@@ -55,6 +60,11 @@ void command_write_flash(int argc, cmp_ctx_t *args, cmp_ctx_t *out, bootloader_c
 
     // refuse to overwrite bootloader or config pages
     if (address < memory_get_app_addr()) {
+        goto command_fail;
+    }
+
+    // Refuse to erase past end of flash memory
+    if (address >= memory_get_app_addr() + memory_get_app_size()) {
         goto command_fail;
     }
 

--- a/platform.h
+++ b/platform.h
@@ -18,6 +18,7 @@ extern uint8_t config_page_buffer[CONFIG_PAGE_SIZE];
 void *memory_get_app_addr(void);
 void *memory_get_config1_addr(void);
 void *memory_get_config2_addr(void);
+size_t memory_get_app_size(void);
 
 #ifdef __cplusplus
 }

--- a/platform/can-io-board/linkerscript.ld
+++ b/platform/can-io-board/linkerscript.ld
@@ -30,6 +30,7 @@ SECTIONS
 
     /* application in flash */
     application_address = ORIGIN(FLASH_APP);
+    application_size = LENGTH(FLASH_APP);
 
     .text :
     {

--- a/platform/can-io-board/platform.h
+++ b/platform/can-io-board/platform.h
@@ -15,11 +15,16 @@ extern "C" {
 extern uint8_t config_page_buffer[CONFIG_PAGE_SIZE];
 
 // symbols defined in linkerscript
-extern int application_address, config_page1, config_page2;
+extern int application_address, application_size, config_page1, config_page2;
 
 static inline void *memory_get_app_addr(void)
 {
     return (void *) &application_address;
+}
+
+static inline size_t memory_get_app_size(void)
+{
+    return (size_t)&application_size;
 }
 
 static inline void *memory_get_config1_addr(void)
@@ -31,6 +36,7 @@ static inline void *memory_get_config2_addr(void)
 {
     return (void *) &config_page2;
 }
+
 
 #ifdef __cplusplus
 }

--- a/platform/motor-board-v1/linkerscript.ld
+++ b/platform/motor-board-v1/linkerscript.ld
@@ -30,6 +30,7 @@ SECTIONS
 
     /* application in flash */
     application_address = ORIGIN(FLASH_APP);
+    application_size = LENGTH(FLASH_APP);
 
     .text :
     {

--- a/platform/motor-board-v1/platform.h
+++ b/platform/motor-board-v1/platform.h
@@ -15,11 +15,16 @@ extern "C" {
 extern uint8_t config_page_buffer[CONFIG_PAGE_SIZE];
 
 // symbols defined in linkerscript
-extern int application_address, config_page1, config_page2;
+extern int application_address, application_size, config_page1, config_page2;
 
 static inline void *memory_get_app_addr(void)
 {
     return (void *) &application_address;
+}
+
+static inline size_t memory_get_app_size(void)
+{
+    return (size_t)&application_size;
 }
 
 static inline void *memory_get_config1_addr(void)
@@ -31,6 +36,7 @@ static inline void *memory_get_config2_addr(void)
 {
     return (void *) &config_page2;
 }
+
 
 #ifdef __cplusplus
 }

--- a/platform/olimex-e407/linkerscript.ld
+++ b/platform/olimex-e407/linkerscript.ld
@@ -29,6 +29,7 @@ SECTIONS
 
     /* application in flash */
     application_address = ORIGIN(FLASH_APP);
+    application_size = LENGTH(FLASH_APP);
 
     .text :
     {

--- a/platform/olimex-e407/platform.h
+++ b/platform/olimex-e407/platform.h
@@ -15,11 +15,16 @@ extern "C" {
 extern uint8_t config_page_buffer[CONFIG_PAGE_SIZE];
 
 // symbols defined in linkerscript
-extern int application_address, config_page1, config_page2;
+extern int application_address, application_size, config_page1, config_page2;
 
 static inline void *memory_get_app_addr(void)
 {
     return (void *) &application_address;
+}
+
+static inline size_t memory_get_app_size(void)
+{
+    return (size_t)&application_size;
 }
 
 static inline void *memory_get_config1_addr(void)
@@ -31,6 +36,7 @@ static inline void *memory_get_config2_addr(void)
 {
     return (void *) &config_page2;
 }
+
 
 #ifdef __cplusplus
 }

--- a/platform/rc-board-v1/linkerscript.ld
+++ b/platform/rc-board-v1/linkerscript.ld
@@ -30,6 +30,7 @@ SECTIONS
 
     /* application in flash */
     application_address = ORIGIN(FLASH_APP);
+    application_size = LENGTH(FLASH_APP);
 
     .text :
     {

--- a/platform/rc-board-v1/platform.h
+++ b/platform/rc-board-v1/platform.h
@@ -15,11 +15,16 @@ extern "C" {
 extern uint8_t config_page_buffer[CONFIG_PAGE_SIZE];
 
 // symbols defined in linkerscript
-extern int application_address, config_page1, config_page2;
+extern int application_address, application_size, config_page1, config_page2;
 
 static inline void *memory_get_app_addr(void)
 {
     return (void *) &application_address;
+}
+
+static inline size_t memory_get_app_size(void)
+{
+    return (size_t)&application_size;
 }
 
 static inline void *memory_get_config1_addr(void)

--- a/tests/mocks/platform_mock.c
+++ b/tests/mocks/platform_mock.c
@@ -20,3 +20,8 @@ void *memory_get_config2_addr(void)
 {
     return &memory_mock_config2[0];
 }
+
+size_t memory_get_app_size(void)
+{
+    return sizeof(memory_mock_app);
+}


### PR DESCRIPTION
This PR implements a check to prevent writing past the end of the flash memory. It should fix a bug where the bootloader could get erased (issue #71).

I implemented the fix for all supported platforms but it is not tested on hardware. Testing on one of the platforms should be enough, since the fix is identical for all.

@nuft could you test this with the test file you found in your issue report?