### PR TITLE
Allow capturing bootloader traffic

### DIFF
--- a/client/can/pcap.py
+++ b/client/can/pcap.py
@@ -1,0 +1,46 @@
+import struct
+
+# See https://wiki.wireshark.org/Development/LibpcapFileFormat
+PCAP_HDR_FORMAT = '=LHHlLLL'
+PCAP_PKT_HDR_FMT = '=4L'
+SOCKETCAN_HDR_FMT = '!LBxxx'
+
+
+def write_header(outfile):
+    magic = 0xa1b2c3d4
+    ver_maj, ver_min = 2, 4
+    thiszone = 0
+    sigfigs = 0
+    snaplen = 65535
+    network = 227  # SocketCAN
+
+    hdr = struct.pack(PCAP_HDR_FORMAT, magic, ver_maj, ver_min, thiszone,
+                      sigfigs, snaplen, network)
+    outfile.write(hdr)
+
+
+def _write_packet_header(outfile, timestamp, packet_length):
+    #ts_sec, ts_usec = int(timestamp), int(1000000 *
+    ts_sec = int(timestamp)
+    ts_usec = int(1000000 * (timestamp - ts_sec))
+
+    hdr = struct.pack(PCAP_PKT_HDR_FMT, ts_sec, ts_usec, packet_length,
+                      packet_length)
+    outfile.write(hdr)
+
+
+def write_frame(outfile, timestamp, frame):
+    _write_packet_header(outfile, timestamp, frame.data_length + 8)
+
+    # Check http://www.tcpdump.org/linktypes/LINKTYPE_CAN_SOCKETCAN.html
+    id_with_flags = frame.id
+
+    if frame.extended:
+        id_with_flags |= 0x80000000
+
+    if frame.transmission_request:
+        id_with_flags |= 0x40000000
+
+    data = struct.pack(SOCKETCAN_HDR_FMT, id_with_flags,
+                       frame.data_length) + frame.data
+    outfile.write(data)

--- a/client/cvra_bootloader/utils.py
+++ b/client/cvra_bootloader/utils.py
@@ -11,6 +11,7 @@ import can.pcap
 
 from collections import defaultdict
 
+
 class ConnectionArgumentParser(argparse.ArgumentParser):
     """
     Subclass of ArgumentParser with default arguments for connection handling (TCP and serial).
@@ -21,18 +22,29 @@ class ConnectionArgumentParser(argparse.ArgumentParser):
     def __init__(self, *args, **kwargs):
         super(ConnectionArgumentParser, self).__init__(*args, **kwargs)
 
-        self.add_argument('-p', '--port', dest='serial_device',
-                          help='Serial port to which the CAN bridge is connected to.',
-                          metavar='DEVICE')
+        self.add_argument(
+            '-p',
+            '--port',
+            dest='serial_device',
+            help='Serial port to which the CAN bridge is connected to.',
+            metavar='DEVICE')
 
-        self.add_argument('-i', '--interface', dest='can_interface',
-                          help="SocketCAN interface, e.g 'can0' (Linux only).",
-                          metavar='INTERFACE')
+        self.add_argument(
+            '-i',
+            '--interface',
+            dest='can_interface',
+            help="SocketCAN interface, e.g 'can0' (Linux only).",
+            metavar='INTERFACE')
 
-        self.add_argument('--pcap', help='Log CAN frames to the given file in Wireshark compatible Pcap format.', type=argparse.FileType('wb'))
+        self.add_argument(
+            '--pcap',
+            help=
+            'Log CAN frames to the given file in Wireshark compatible Pcap format.',
+            type=argparse.FileType('wb'))
 
     def parse_args(self, *args, **kwargs):
-        args = super(ConnectionArgumentParser, self).parse_args(*args, **kwargs)
+        args = super(ConnectionArgumentParser, self).parse_args(
+            *args, **kwargs)
 
         if args.serial_device is None and \
            args.can_interface is None:
@@ -43,10 +55,12 @@ class ConnectionArgumentParser(argparse.ArgumentParser):
 
         return args
 
+
 class SocketSerialAdapter:
     """
     This class wraps a socket in an API compatible with PySerial's one.
     """
+
     def __init__(self, socket):
         self.socket = socket
 
@@ -56,18 +70,19 @@ class SocketSerialAdapter:
         except socket.timeout:
             return bytes()
 
-
     def write(self, data):
         return self.socket.send(data)
 
     def flush(self):
         pass
 
+
 class PcapConnectionWrapper:
     """
     Connection wrapper which logs all frames sent and received into a wireshark
     compatible pcap file.
     """
+
     def __init__(self, conn, pcap_file):
         self.conn = conn
         self.pcap_file = pcap_file
@@ -92,7 +107,7 @@ def open_connection(args):
     """
     conn = None
     if args.can_interface:
-        conn =  can.adapters.SocketCANConnection(args.can_interface)
+        conn = can.adapters.SocketCANConnection(args.can_interface)
     elif args.serial_device:
         port = serial.Serial(port=args.serial_device, timeout=0.1)
         conn = can.adapters.SerialCANConnection(port)
@@ -101,6 +116,7 @@ def open_connection(args):
         conn = PcapConnectionWrapper(conn, args.pcap)
 
     return conn
+
 
 def read_can_datagrams(fdesc):
     buf = defaultdict(lambda: bytes())

--- a/client/setup.py
+++ b/client/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='cvra-bootloader',
-    version='2.1.0',
+    version='2.2.0',
     description='Client for the CVRA CAN bootloader',
     author='Club Vaudois de Robotique Autonome',
     author_email='info@cvra.ch',

--- a/client/tests/test_pcap_file.py
+++ b/client/tests/test_pcap_file.py
@@ -1,0 +1,56 @@
+import unittest
+import io
+import struct
+from can.frame import Frame
+from can.pcap import *
+from socket import ntohl
+
+# needed to expose private api
+from can.pcap import _write_packet_header
+
+
+class PCAPTest(unittest.TestCase):
+    def test_write_file_header(self):
+        f = io.BytesIO()
+        write_header(f)
+
+        header = struct.unpack('=LHHlLLL', f.getvalue())
+        self.assertEqual(0xa1b2c3d4, header[0], 'bad magic header')
+        self.assertEqual(2, header[1], 'bad version major')
+        self.assertEqual(4, header[2], 'bad version minor')
+        self.assertEqual(0, header[3], 'timezone is not GMT')
+        # Sigfigs is not really used
+        self.assertEqual(65535, header[5], 'bad snapshot length')
+        self.assertEqual(227, header[6], 'network type is not socketcan')
+
+    def test_write_packet_header(self):
+        f = io.BytesIO()
+        ts = 1000.5
+        packet_length = 10
+        _write_packet_header(f, ts, packet_length)
+
+        header = struct.unpack('=4L', f.getvalue())
+
+        self.assertEqual(1000, header[0], 'Invalid ts_sec')
+        self.assertEqual(500000, header[1], 'Invalid ts_usec')
+        self.assertEqual(10, header[2], 'Invalid incl_len')
+        self.assertEqual(10, header[3], 'Invalid orig_len')
+
+    def test_write_frame(self):
+        f = io.BytesIO()
+        ts = 1000.5
+        data = "hello".encode()
+        frame = Frame(0xcafe, data, extended=True, transmission_request=True)
+
+        write_frame(f, ts, frame)
+
+        fmt = PCAP_PKT_HDR_FMT + 'LBxxx' + '5s'
+        data = struct.unpack(fmt, f.getvalue())
+
+        # Check CAN ID (see http://www.tcpdump.org/linktypes/LINKTYPE_CAN_SOCKETCAN.html)
+        expected_id = 0x40000000 + 0x80000000 + 0xcafe
+
+        # The ID is stored in network byte order so we need to convert it to
+        # host byte order before sending it
+        self.assertEqual(data[4], ntohl(expected_id), 'wrong can id')
+        self.assertEqual(data[5], 5, 'wrong frame length')

--- a/client/tests/test_utils.py
+++ b/client/tests/test_utils.py
@@ -12,12 +12,14 @@ from cvra_bootloader import commands
 import msgpack
 import io
 
+
 @patch('cvra_bootloader.utils.read_can_datagrams')
 @patch('cvra_bootloader.utils.write_command')
 class BoardPingTestCase(unittest.TestCase):
     """
     Checks for the ping_board function.
     """
+
     def test_sends_correct_command(self, write_command, read_datagram):
         port = object()
         ping_board(port, 1)
@@ -56,7 +58,6 @@ class WriteCommandTestCase(unittest.TestCase):
             fdesc.send_frame.assert_any_call(f)
 
 
-
 @patch('cvra_bootloader.utils.read_can_datagrams')
 @patch('cvra_bootloader.utils.write_command')
 class CommandRetryTestCase(unittest.TestCase):
@@ -91,7 +92,7 @@ class CommandRetryTestCase(unittest.TestCase):
         read.return_value = repeat(None)  # Timeout forever
         data = "hello"
 
-        with patch('logging.warning'),  patch('logging.critical') as critical:
+        with patch('logging.warning'), patch('logging.critical') as critical:
             with self.assertRaises(IOError):
                 write_command_retry(None, data, [1, 2], retry_limit=2)
 
@@ -99,6 +100,7 @@ class CommandRetryTestCase(unittest.TestCase):
             # message
             self.assertEqual(write.call_count, 2 + 1)
             critical.assert_any_call(ANY)
+
 
 class PCAPWrapperTestCase(unittest.TestCase):
     def setUp(self):
@@ -137,15 +139,21 @@ class PCAPWrapperTestCase(unittest.TestCase):
         """
         Checks that read timeoutes are not logged in the pcap.
         """
-        self.underlying_conn.receive_frame.return_value = None # timeout
+        self.underlying_conn.receive_frame.return_value = None  # timeout
         self.assertIsNone(self.conn.receive_frame())
-        self.assertEqual(24, len(self.outfile.getvalue()), 'pcap should only contain header')
+        self.assertEqual(24,
+                         len(self.outfile.getvalue()),
+                         'pcap should only contain header')
+
 
 class OpenConnectionTestCase(unittest.TestCase):
     Args = namedtuple("Args", ["serial_device", "can_interface", "pcap"])
 
     def make_args(self, serial_device=None, can_interface=None, pcap=None):
-        return self.Args(serial_device=serial_device, can_interface=can_interface, pcap=pcap)
+        return self.Args(
+            serial_device=serial_device,
+            can_interface=can_interface,
+            pcap=pcap)
 
     @patch('can.adapters.SocketCANConnection', autospec=True)
     def test_open_can_interface(self, create_socket):
@@ -175,4 +183,3 @@ class ArgumentParserTestCase(unittest.TestCase):
         args = parser.parse_args("-i can0".split())
 
         self.assertEqual('can0', args.can_interface)
-


### PR DESCRIPTION
So, I am debugging this weird issue that pops on when using the bootloader on UWB beacons, when suddenly I am like "dude, watching frames in wireshark would be so much better". Turns out the pcap file format is pretty easy to implement, and this is what i did. 

For linux users, this is mostly useless, as they can already do that if they use the CAN adapter in SocketCAN (which they should), but for OSX users, this is pretty great. Maybe it would be better to have this code live somewhere else as it can be used for other applications than just the bootloader, but I just don't really know where.

What do you guys think? An example capture is enclosed (one board connected, network scanned with `bootloader_read_config -a -p /dev/tty.usbmodem301 --pcap read_conf.pcap`). I had to zip it as Github wont allow me to upload .pcap files.

[read_conf.pcap.zip](https://github.com/cvra/can-bootloader/files/1425511/read_conf.pcap.zip)
