### PR TITLE
Reduce code size by linking with newlib-nano

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -21,7 +21,7 @@ case $BUILD_TYPE in
     tests)
         # Install cpputest
         pushd ..
-        wget "https://github.com/cpputest/cpputest.github.io/blob/master/releases/cpputest-3.8.tar.gz?raw=true" -O cpputest.tar.gz
+        wget "https://github.com/cpputest/cpputest/releases/download/v3.8/cpputest-3.8.tar.gz" -O cpputest.tar.gz
         tar -xzf cpputest.tar.gz
         cd cpputest-3.8/
         ./configure --prefix=$HOME/cpputest

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -21,9 +21,9 @@ case $BUILD_TYPE in
     tests)
         # Install cpputest
         pushd ..
-        wget "https://github.com/cpputest/cpputest.github.io/blob/master/releases/cpputest-3.6.tar.gz?raw=true" -O cpputest.tar.gz
+        wget "https://github.com/cpputest/cpputest.github.io/blob/master/releases/cpputest-3.8.tar.gz?raw=true" -O cpputest.tar.gz
         tar -xzf cpputest.tar.gz
-        cd cpputest-3.6/
+        cd cpputest-3.8/
         ./configure --prefix=$HOME/cpputest
         make
         make install

--- a/platform/can-io-board/Makefile
+++ b/platform/can-io-board/Makefile
@@ -54,6 +54,7 @@ CXXFLAGS += -fno-use-cxa-atexit
 # Linker flags
 LFLAGS   += $(LIBS) -T$(LDSCRIPT) -nostartfiles -Wl,-Map=$(PROJNAME).map
 LFLAGS   += -Wl,--gc-sections
+LFLAGS   += -lc_nano
 
 CCFLAGS  += $(CFLAGS)
 CXXFLAGS += $(CFLAGS)

--- a/platform/motor-board-v1/Makefile
+++ b/platform/motor-board-v1/Makefile
@@ -54,6 +54,7 @@ CXXFLAGS += -fno-use-cxa-atexit
 # Linker flags
 LFLAGS   += $(LIBS) -T$(LDSCRIPT) -nostartfiles -Wl,-Map=$(PROJNAME).map
 LFLAGS   += -Wl,--gc-sections
+LFLAGS   += -lc_nano
 
 CCFLAGS  += $(CFLAGS)
 CXXFLAGS += $(CFLAGS)

--- a/tests/mocks/can_interface_mock.cpp
+++ b/tests/mocks/can_interface_mock.cpp
@@ -13,8 +13,7 @@ bool can_interface_read_message(uint32_t *id, uint8_t *message, uint8_t *length,
     mock("can").actualCall("read")
                .withOutputParameter("id", id)
                .withOutputParameter("message", message)
-               .withOutputParameter("length", length)
-               .returnIntValue();
+               .withOutputParameter("length", length);
     return true;
 }
 
@@ -36,8 +35,7 @@ void can_mock_message(uint32_t message_id, uint8_t *msg, uint8_t message_len)
     mock("can").expectOneCall("read")
                .withOutputParameterReturning("id", &expected_id, sizeof(uint32_t))
                .withOutputParameterReturning("message", expected_msg, message_len)
-               .withOutputParameterReturning("length", &expected_len, sizeof(uint8_t))
-               .andReturnValue(true);
+               .withOutputParameterReturning("length", &expected_len, sizeof(uint8_t));
 }
 
 TEST_GROUP(CanInterfaceMockTestGroup)


### PR DESCRIPTION
This commit reduces code size enough to fix issue #76. It does so by
linking against a version of newlib optimized for code size. With this
commit enabled, the motor board platform only takes 8.7kB where it used
to overflow the 10kB limit. This fix was tested on motor-board hardware
and since it passed I also enabled it on can-io.

I am not sure if this is toolchain specific, but I was able to run it in my `antoinealb/gcc-arm-embedded` image, so it should work at least on OSX and Ubuntu.