### PR TITLE
Fix STM32F4 erase time

### DIFF
--- a/bootloader.c
+++ b/bootloader.c
@@ -8,6 +8,7 @@
 #include "boot_arg.h"
 #include "timeout.h"
 #include "can_interface.h"
+#include "flash_writer.h"
 
 #define BUFFER_SIZE         FLASH_PAGE_SIZE + 128
 #define DEFAULT_ID          0x01
@@ -69,6 +70,8 @@ static void return_datagram(uint8_t source_id, uint8_t dest_id, uint8_t *data, s
 void bootloader_main(int arg)
 {
     bool timeout_active = !(arg == BOOT_ARG_START_BOOTLOADER_NO_TIMEOUT);
+
+    flash_init();
 
     bootloader_config_t config;
     if (config_is_valid(memory_get_config1_addr(), CONFIG_PAGE_SIZE)) {

--- a/client/can/adapters.py
+++ b/client/can/adapters.py
@@ -134,6 +134,9 @@ class SerialCANConnection:
 
     def receive_frame(self):
         try:
-            return self.rx_queue.get(True, 1) # block with timeout 1 sec
+            # according to the datasheet, erasing a sector from an stm32f407
+            # can take up to 4 seconds. Therefore wait for 5 seconds before
+            # assuming nobody answered.
+            return self.rx_queue.get(True, 5)
         except:
             return None

--- a/flash_writer.h
+++ b/flash_writer.h
@@ -8,6 +8,9 @@
 extern "C" {
 #endif
 
+/** Initializes anything needed before flash can be accessed */
+void flash_init(void);
+
 /** Unlocks the flash for programming. */
 void flash_writer_unlock(void);
 

--- a/platform/mcu/stm32f1/flash_writer.c
+++ b/platform/mcu/stm32f1/flash_writer.c
@@ -8,6 +8,9 @@
 #define FLASH_PROGRAM_SIZE 0 // default: 8-bit
 #endif
 
+void flash_init(void)
+{
+}
 
 void flash_writer_unlock(void)
 {

--- a/platform/mcu/stm32f3/flash_writer.c
+++ b/platform/mcu/stm32f3/flash_writer.c
@@ -1,6 +1,9 @@
-
 #include <libopencm3/stm32/flash.h>
 #include "flash_writer.h"
+
+void flash_init(void)
+{
+}
 
 void flash_writer_unlock(void)
 {

--- a/platform/mcu/stm32f4/flash_writer.c
+++ b/platform/mcu/stm32f4/flash_writer.c
@@ -8,6 +8,10 @@
 #define FLASH_PROGRAM_SIZE 0 // default: 8-bit
 #endif
 
+#define SECTOR_COUNT 24
+
+static int sector_erased[SECTOR_COUNT];
+
 static uint8_t flash_addr_to_sector(uint32_t addr)
 {
     uint8_t sector;
@@ -26,6 +30,13 @@ static uint8_t flash_addr_to_sector(uint32_t addr)
     return sector;
 }
 
+void flash_init(void)
+{
+    for (int i = 0; i < SECTOR_COUNT; i++) {
+        sector_erased[i] = 0;
+    }
+}
+
 void flash_writer_unlock(void)
 {
     flash_unlock();
@@ -39,10 +50,15 @@ void flash_writer_lock(void)
 void flash_writer_page_erase(void *page)
 {
     uint8_t sector = flash_addr_to_sector((uint32_t)page);
-    flash_erase_sector(sector, FLASH_PROGRAM_SIZE);
+    if (sector_erased[sector] == 0) {
+        sector_erased[sector] = 1;
+        flash_erase_sector(sector, FLASH_PROGRAM_SIZE);
+    }
 }
 
 void flash_writer_page_write(void *page, void *data, size_t len)
 {
+    uint8_t sector = flash_addr_to_sector((uint32_t)page);
+    sector_erased[sector] = 0;
     flash_program((uint32_t)page, data, len);
 }

--- a/platform/uwb-beacon/Makefile
+++ b/platform/uwb-beacon/Makefile
@@ -117,6 +117,12 @@ rebuild: clean all
 flash: all
 	openocd -f oocd.cfg -c "program $(PROJNAME).elf verify reset" -c "shutdown"
 
+.PHONY: dfu
+dfu: $(PROJNAME).bin
+	# 0483:df11 is the USB Vendor ID:Product ID pair for an STM32 in DFU
+	# bootloader mode. It can be found by running lsusb under Linux.
+	dfu-util -a 0 -d 0483:df11 --dfuse-address 0x08000000 -D $(PROJNAME).bin
+
 .PHONY: reset
 reset:
 	openocd -f oocd.cfg -c "init" -c "reset" -c "shutdown"

--- a/tests/mocks/flash_writer_mock.cpp
+++ b/tests/mocks/flash_writer_mock.cpp
@@ -8,6 +8,10 @@ extern "C" {
 int app_start;
 }
 
+void flash_init(void)
+{
+}
+
 void flash_writer_unlock(void)
 {
     mock("flash").actualCall("unlock");


### PR DESCRIPTION
This pull request enables flashing of STM32F4 based boards in a reasonable time. It does so by avoiding erasing several time the same "big" sector which is expensive to do on this platform. See commits for implementation details.

The alternative would have been to make the client aware of the more complex sector layout to avoid erasing unnecessary sectors. However this meant either more client-side configuration (commandline flags) to indicate that this is an STM32F4 or a discovery step (for example by reading the board config). In the end I feel that "hacking" the interface leads to a simpler system.

Flashing time with this path is about 30s for the UWB firmware, which is reasonable enough to allow in system flashing of the board.

As a bonus I added a blink pattern to identify the boards which boot in bootloader mode.

Fixes #81 