### PR TITLE
Allow different timeouts based on device size

### DIFF
--- a/client/cvra_bootloader/utils.py
+++ b/client/cvra_bootloader/utils.py
@@ -42,6 +42,11 @@ class ConnectionArgumentParser(argparse.ArgumentParser):
             'Log CAN frames to the given file in Wireshark compatible Pcap format.',
             type=argparse.FileType('wb'))
 
+        self.add_argument("--large-pages",
+                help="Specify that the device has large pages, and that it requires longer erase timeout.",
+                action="store_true")
+
+
     def parse_args(self, *args, **kwargs):
         args = super(ConnectionArgumentParser, self).parse_args(
             *args, **kwargs)
@@ -106,11 +111,17 @@ def open_connection(args):
     Returns a file like object which will be the connection handle.
     """
     conn = None
+
+    if args.large_pages:
+        timeout = 5
+    else:
+        timeout = 0.5
+
     if args.can_interface:
-        conn = can.adapters.SocketCANConnection(args.can_interface)
+        conn = can.adapters.SocketCANConnection(args.can_interface, read_timeout=timeout)
     elif args.serial_device:
         port = serial.Serial(port=args.serial_device, timeout=0.1)
-        conn = can.adapters.SerialCANConnection(port)
+        conn = can.adapters.SerialCANConnection(port, read_timeout=timeout)
 
     if args.pcap:
         conn = PcapConnectionWrapper(conn, args.pcap)

--- a/client/tests/test_utils.py
+++ b/client/tests/test_utils.py
@@ -147,13 +147,14 @@ class PCAPWrapperTestCase(unittest.TestCase):
 
 
 class OpenConnectionTestCase(unittest.TestCase):
-    Args = namedtuple("Args", ["serial_device", "can_interface", "pcap"])
+    Args = namedtuple("Args", ["serial_device", "can_interface", "pcap", "large_pages"])
 
-    def make_args(self, serial_device=None, can_interface=None, pcap=None):
+    def make_args(self, serial_device=None, can_interface=None, pcap=None, large_pages=False):
         return self.Args(
             serial_device=serial_device,
             can_interface=can_interface,
-            pcap=pcap)
+            pcap=pcap,
+            large_pages=large_pages)
 
     @patch('can.adapters.SocketCANConnection', autospec=True)
     def test_open_can_interface(self, create_socket):
@@ -162,7 +163,7 @@ class OpenConnectionTestCase(unittest.TestCase):
         """
         args = self.make_args(can_interface='can0')
         conn = open_connection(args)
-        create_socket.assert_any_call('can0')
+        create_socket.assert_any_call('can0', read_timeout=ANY)
         self.assertEqual(conn, create_socket.return_value)
 
     @patch('can.adapters.SocketCANConnection', autospec=True)
@@ -173,7 +174,7 @@ class OpenConnectionTestCase(unittest.TestCase):
         outfile = io.BytesIO()
         args = self.make_args(can_interface='can0', pcap=outfile)
         conn = open_connection(args)
-        create_socket.assert_any_call('can0')
+        create_socket.assert_any_call('can0', ANY)
         self.assertEqual(conn.conn, create_socket.return_value)
 
 


### PR DESCRIPTION
On large devices, such as the F4s, erasing a page can take a very long
time (up to 4 seconds), and therefore we do want to have generous timeouts
as well. However, this means that the user experience is much worse in
smaller devices such as the F3s.

Since we mostly use the bootloader with small devices, the short timeout
is the default and F4 users should pass --large-pages.